### PR TITLE
Setup CircleCi to run ERC with "librepcb-cli"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2
+
+jobs:
+  erc:
+    docker:
+      - image: debian:9
+    steps:
+      - checkout
+      - run:
+          name: Download librepcb-cli
+          command: wget https://download.librepcb.org/nightly_builds/add-cli/librepcb-cli-nightly-linux-x86_64.AppImage
+      - run:
+          name: Extract librepcb-cli
+          command: |
+            chmod a+x ./librepcb-cli-nightly-linux-x86_64.AppImage &&
+            ./librepcb-cli-nightly-linux-x86_64.AppImage --appimage-extract &&
+            ln -s ./squashfs-root/AppRun ./librepcb-cli
+      - run:
+          name: Run ERC
+          command: xvfb-run -a ./librepcb-cli open-project --erc desklift
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - erc


### PR DESCRIPTION
Based on #1.

Sorry @ubruhin, I prefer CircleCI :slightly_smiling_face: We should make a LibrePCB CLI base image for CI btw.